### PR TITLE
Add clickPreventDefault option

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -6,7 +6,7 @@ function IScroll (el, options) {
 
 	this.options = {
 
-// INSERT POINT: OPTIONS 
+// INSERT POINT: OPTIONS
 
 		startX: 0,
 		startY: 0,
@@ -57,7 +57,7 @@ function IScroll (el, options) {
 
 // INSERT POINT: NORMALIZATION
 
-	// Some defaults	
+	// Some defaults
 	this.x = 0;
 	this.y = 0;
 	this.directionX = 0;
@@ -552,7 +552,7 @@ IScroll.prototype = {
 		eventType(window, 'orientationchange', this);
 		eventType(window, 'resize', this);
 
-		if ( this.options.click ) {
+		if ( this.options.click || this.options.clickPreventDefault ) {
 			eventType(this.wrapper, 'click', this, true);
 		}
 

--- a/src/default/handleEvent.js
+++ b/src/default/handleEvent.js
@@ -42,7 +42,7 @@
 				this._key(e);
 				break;
 			case 'click':
-				if ( !e._constructed ) {
+				if ( !e._constructed || this.options.clickPreventDefault ) {
 					e.preventDefault();
 					e.stopPropagation();
 				}


### PR DESCRIPTION
when we scroll and stop scrolling after, click event still fired, it is sometime a not desired behavior, add an option to Iscroll to always suppress the click event

poke @bjornstar 
