### PR TITLE
Make iscroll always handle click event

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -287,7 +287,7 @@ IScroll.prototype = {
 			}
 
 			if ( this.options.click ) {
-				utils.click(e);
+				utils.click(e, this.options);
 			}
 
 			this._execEvent('scrollCancel');
@@ -552,9 +552,7 @@ IScroll.prototype = {
 		eventType(window, 'orientationchange', this);
 		eventType(window, 'resize', this);
 
-		if ( this.options.click || this.options.clickPreventDefault ) {
-			eventType(this.wrapper, 'click', this, true);
-		}
+		eventType(this.wrapper, 'click', this, true);
 
 		if ( !this.options.disableMouse ) {
 			eventType(this.wrapper, 'mousedown', this);

--- a/src/default/handleEvent.js
+++ b/src/default/handleEvent.js
@@ -42,7 +42,7 @@
 				this._key(e);
 				break;
 			case 'click':
-				if ( !e._constructed || this.options.clickPreventDefault ) {
+				if ( !e._constructed && !utils.preventDefaultException(e.target, this.options.preventDefaultException) ) {
 					e.preventDefault();
 					e.stopPropagation();
 				}

--- a/src/utils.js
+++ b/src/utils.js
@@ -224,11 +224,11 @@ var utils = (function () {
 		e.target.dispatchEvent(ev);
 	};
 
-	me.click = function (e) {
+	me.click = function (e, options) {
 		var target = e.target,
 			ev;
 
-		if ( !(/(SELECT|INPUT|TEXTAREA)/i).test(target.tagName) ) {
+		if ( !me.preventDefaultException(target, options.preventDefaultException) ) {
 			ev = document.createEvent('MouseEvents');
 			ev.initMouseEvent('click', true, true, e.view, 1,
 				target.screenX, target.screenY, target.clientX, target.clientY,


### PR DESCRIPTION
changes: 
- click events are now always handled, click event is blocked if it is not iscroll custom click event and do not satisfy preventDefaultException (hence input, textarea, button and select tag is not blocked)
- remove clickPreventDefault option since click events are properly handled now
- unify preventDefaultException usage
