### PR TITLE
Reset initiated if we disable

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -363,6 +363,7 @@ IScroll.prototype = {
 
 	disable: function () {
 		this.enabled = false;
+		this.initiated = false;
 	},
 
 	enable: function () {


### PR DESCRIPTION
when we disable, previous initiated state is still store. After we enable scrolling, some event get trigger because we have a initiated state.
